### PR TITLE
Relax the version constraint on `cuda-version` for nvJitLink dev/static packages too

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@
 /build_artifacts
 
 *.pyc
+
+# Rattler-build's artifacts are in `output` when not specifying anything.
+/output
+# Pixi's configuration
+.pixi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ source:
   sha256: 8258afaadbd9744d87070525067c497041dd52c6b22d11ba7297421fc8f6f39d  # [win]
 
 build:
-  number: 0
+  number: 1
   binary_relocation: false
   skip: true  # [osx or ppc64le]
 
@@ -95,7 +95,10 @@ outputs:
       host:
         - cuda-version {{ cuda_version }}
       run:
-        - {{ pin_compatible("cuda-version", max_pin="x.x") }}
+        # xref: conda-forge/libnvjitlink-feedstock#15
+        # we want to allow ex: libnvjitlink=12.6 installed in a cuda-version=12.3 environment,
+        # both within the same CUDA major.
+        - {{ pin_compatible("cuda-version", min_pin="x", max_pin="x.x") }}
         - {{ pin_subpackage("libnvjitlink", exact=True) }}
       run_constrained:
         - arm-variant * {{ arm_variant_type }}  # [aarch64]
@@ -131,7 +134,10 @@ outputs:
       host:
         - cuda-version {{ cuda_version }}
       run:
-        - {{ pin_compatible("cuda-version", max_pin="x.x") }}
+        # xref: conda-forge/libnvjitlink-feedstock#15
+        # we want to allow ex: libnvjitlink=12.6 installed in a cuda-version=12.3 environment,
+        # both within the same CUDA major.
+        - {{ pin_compatible("cuda-version", min_pin="x", max_pin="x.x") }}
       run_constrained:
         - arm-variant * {{ arm_variant_type }}  # [aarch64]
     test:


### PR DESCRIPTION
Follow up for conda-forge/libnvjitlink-feedstock#15. This is needed for build applications that dynamically or statically link to nvJitLink. Without this PR this use case is blocked.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
